### PR TITLE
Sample code for authorization only and void transaction (Paypal)

### DIFF
--- a/PaypalExpressCheckout/authorize-only.rb
+++ b/PaypalExpressCheckout/authorize-only.rb
@@ -1,0 +1,29 @@
+require 'rubygems'
+  require 'yaml'
+  require 'authorizenet'
+
+  include AuthorizeNet::API
+
+  config = YAML.load_file(File.dirname(__FILE__) + "/../credentials.yml")
+
+  transaction = Transaction.new(config['paypal_api_login_id'], config['paypal_api_transaction_key'], :gateway => :sandbox)
+
+  request = CreateTransactionRequest.new
+
+  request.transactionRequest = TransactionRequestType.new()
+  request.transactionRequest.amount = 5.00
+  request.transactionRequest.payment = PaymentType.new
+  request.transactionRequest.payment.payPal = PayPalType.new(succesUrl="http://www.merchanteCommerceSite.com/Success/TC25262", cancelUrl="http://www.merchanteCommerceSite.com/Success/TC25262")
+  request.transactionRequest.transactionType = TransactionTypeEnum::AuthOnlyTransaction
+  
+  response = transaction.create_transaction(request)
+
+  if response.messages.resultCode == MessageTypeEnum::Ok
+    puts "Successfully created a AuthorizeOnly transaction (authorization code: #{response.transactionResponse.authCode})"
+
+  else
+    puts response.messages.messages[0].text
+    puts response.transactionResponse.errors.errors[0].errorCode
+    puts response.transactionResponse.errors.errors[0].errorText
+    raise "Failed to make purchase."
+  end

--- a/PaypalExpressCheckout/void.rb
+++ b/PaypalExpressCheckout/void.rb
@@ -1,0 +1,53 @@
+require 'rubygems'
+  require 'yaml'
+  require 'authorizenet'
+
+  include AuthorizeNet::API
+
+  config = YAML.load_file(File.dirname(__FILE__) + "/../credentials.yml")
+
+  transaction = Transaction.new(config['paypal_api_login_id'], config['paypal_api_transaction_key'], :gateway => :sandbox)
+
+  request = CreateTransactionRequest.new
+
+  request.transactionRequest = TransactionRequestType.new()
+  request.transactionRequest.amount = 16.00
+  request.transactionRequest.payment = PaymentType.new
+  request.transactionRequest.payment.creditCard = CreditCardType.new('4242424242424242','0220','123') 
+  request.transactionRequest.transactionType = TransactionTypeEnum::AuthCaptureTransaction
+  
+  response = transaction.create_transaction(request)
+
+  authTransId = 0
+
+  if response.messages.resultCode == MessageTypeEnum::Ok
+    puts "Successful AuthCapture Transaction (authorization code: #{response.transactionResponse.authCode})"
+    authTransId = response.transactionResponse.transId
+    puts "Transaction ID (for later void: #{authTransId})"
+
+  else
+    puts response.messages.messages[0].text
+    puts response.transactionResponse.errors.errors[0].errorCode
+    puts response.transactionResponse.errors.errors[0].errorText
+    raise "Failed to authorize card."
+  end
+
+  request = CreateTransactionRequest.new
+
+  request.transactionRequest = TransactionRequestType.new()
+  request.transactionRequest.refTransId = authTransId
+  request.transactionRequest.payment = PaymentType.new
+  request.transactionRequest.payment.payPal = PayPalType.new(succesUrl="", cancelUrl="")
+  request.transactionRequest.transactionType = TransactionTypeEnum::VoidTransaction
+  
+  response = transaction.create_transaction(request)
+
+  if response.messages.resultCode == MessageTypeEnum::Ok
+    puts "Successfully voided the transaction (Transaction ID: #{response.transactionResponse.transId})"
+
+  else
+    puts response.messages.messages[0].text
+    puts response.transactionResponse.errors.errors[0].errorCode
+    puts response.transactionResponse.errors.errors[0].errorText
+    raise "Failed to void the transaction."
+  end

--- a/credentials.yml
+++ b/credentials.yml
@@ -1,5 +1,8 @@
 #obtain an API login_id and transaction_id according to instructions at https://developer.authorize.net/faqs/#gettranskey
 api_login_id: 556KThWQ6vf2
 api_transaction_key: 9ac2932kQ7kN2Wzq
+
+paypal_api_login_id: 5KP3u95bQpv
+paypal_api_transaction_key: 4Ktq966gC55GAX7S
 #obtained md5 hash value by first setting the hash value in https://sandbox.authorize.net/ under the Account tab->MD5 Hash
 md5_value: MD5_TEST


### PR DESCRIPTION
Adding sample code for authorization only transaction and void transaction that voids a credit card transaction using paypal. Also adding credentials of dummy paypal account for testing purpose.