### PR TITLE
Set email as correct parameter to CustomerType

### DIFF
--- a/PaymentTransactions/charge-credit-card.rb
+++ b/PaymentTransactions/charge-credit-card.rb
@@ -17,7 +17,7 @@ require 'rubygems'
     request.transactionRequest.amount = ((SecureRandom.random_number + 1 ) * 150 ).round(2)
     request.transactionRequest.payment = PaymentType.new
     request.transactionRequest.payment.creditCard = CreditCardType.new('4242424242424242','0220','123') 
-    request.transactionRequest.customer = CustomerType.new(nil,'bmc@mail.com')
+    request.transactionRequest.customer = CustomerType.new(nil, nil, 'bmc@mail.com')
     request.transactionRequest.transactionType = TransactionTypeEnum::AuthCaptureTransaction
     
     response = transaction.create_transaction(request)


### PR DESCRIPTION
CustomerType takes the ID as second parameter and email as third parameter; this sample code, sending the email as the ID, works in the sandbox (inexplicably), but fails in production, where it returns an error — "The actual length is greater than the MaxLength value".