### PR TITLE
Update compute-transhash-sha512.rb

### DIFF
--- a/Sha512/compute-transhash-sha512.rb
+++ b/Sha512/compute-transhash-sha512.rb
@@ -21,8 +21,9 @@ def calculate_TransHashSha512(signatureKey,textToHash)
         if(!textToHash || textToHash.length == 0)
             raise 'textToHash  cannot be null or empty';
         end
-        if(signatureKey.length>2 || signatureKey.length%2!=0)
+        if(signatureKey.length<2 || signatureKey.length%2!=0)
             raise 'Signature Key cannot be less than 2 or odd';
+        end
         digest = OpenSSL::Digest.new('sha512')
         return OpenSSL::HMAC.hexdigest(digest, [signatureKey].pack('H*'), textToHash).upcase
 end


### PR DESCRIPTION
The original code never calls `calculate_TransHashSha512`, this fix does.

Additionally, this fixed code doesn't seem to calculate the same hash that `test.authorize.net/gateway/trasact.dll` site returns for SIM hosted page forms. Can someone verify the correct text to hash for SIM?