### PR TITLE
Add transactionResponse.responseCode checks

### DIFF
--- a/PaymentTransactions/authorize-credit-card.rb
+++ b/PaymentTransactions/authorize-credit-card.rb
@@ -62,7 +62,7 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
-          if response.transctionResponse.responseCode == '1'
+          if response.transactionResponse.responseCode == '1'
             puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
             puts "Transaction ID: #{response.transactionResponse.transId}"
             puts "Transaction Response Code: #{response.transactionResponse.responseCode}"

--- a/PaymentTransactions/authorize-credit-card.rb
+++ b/PaymentTransactions/authorize-credit-card.rb
@@ -74,8 +74,11 @@ require 'securerandom'
             end
           else
             puts 'Transaction Failed'
-            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
-            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            if response.transactionResponse.errors != nil
+              puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+              puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            end
+            raise "Failed to authorize card."
           end
         else
           puts "Transaction Failed" 

--- a/PaymentTransactions/authorize-credit-card.rb
+++ b/PaymentTransactions/authorize-credit-card.rb
@@ -62,14 +62,20 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
-          puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
-          puts "Transaction ID: #{response.transactionResponse.transId}"
-          puts "Transaction Response Code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
-          puts "User Fields: "
-          response.transactionResponse.userFields.userFields.each do |userField|
-            puts userField.value
+          if response.transctionResponse.responseCode == '1'
+            puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
+            puts "Transaction ID: #{response.transactionResponse.transId}"
+            puts "Transaction Response Code: #{response.transactionResponse.responseCode}"
+            puts "Code: #{response.transactionResponse.messages.messages[0].code}"
+            puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+            puts "User Fields: "
+            response.transactionResponse.userFields.userFields.each do |userField|
+              puts userField.value
+            end
+          else
+            puts 'Transaction Failed'
+            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
           end
         else
           puts "Transaction Failed" 

--- a/PaymentTransactions/capture-funds-authorized-through-another-channel.rb
+++ b/PaymentTransactions/capture-funds-authorized-through-another-channel.rb
@@ -24,10 +24,16 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
-          puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
-          puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          if response.transactionResponse.responseCode == '1'
+            puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
+            puts "Transaction Response code: #{response.transactionResponse.responseCode}"
+            puts "Code: #{response.transactionResponse.messages.messages[0].code}"
+            puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          else
+            puts 'Transaction Failed'
+            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+          end
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/capture-funds-authorized-through-another-channel.rb
+++ b/PaymentTransactions/capture-funds-authorized-through-another-channel.rb
@@ -31,8 +31,11 @@ require 'securerandom'
             puts "Description: #{response.transactionResponse.messages.messages[0].description}"
           else
             puts 'Transaction Failed'
-            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
-            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            if response.transactionResponse.errors != nil
+              puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+              puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            end
+            raise "Failed to authorize card."
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/capture-previously-authorized-amount.rb
+++ b/PaymentTransactions/capture-previously-authorized-amount.rb
@@ -27,11 +27,17 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
-          puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
-          puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
-          puts "Transaction ID: #{response.transactionResponse.transId} (for later capture)"
+          if response.transactionResponse.responseCode == '1'
+            puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
+            puts "Transaction Response code: #{response.transactionResponse.responseCode}"
+            puts "Code: #{response.transactionResponse.messages.messages[0].code}"
+            puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+            puts "Transaction ID: #{response.transactionResponse.transId} (for later capture)"
+          else
+            puts 'Transaction Failed'
+            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+          end
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/capture-previously-authorized-amount.rb
+++ b/PaymentTransactions/capture-previously-authorized-amount.rb
@@ -35,8 +35,11 @@ require 'securerandom'
             puts "Transaction ID: #{response.transactionResponse.transId} (for later capture)"
           else
             puts 'Transaction Failed'
-            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
-            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            if response.transactionResponse.errors != nil
+              puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+              puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            end
+            raise "Failed to authorize card."
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/charge-credit-card.rb
+++ b/PaymentTransactions/charge-credit-card.rb
@@ -63,14 +63,20 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
-          puts "Successful charge (auth + capture) (authorization code: #{response.transactionResponse.authCode})"
-          puts "Transaction ID: #{response.transactionResponse.transId}"
-          puts "Transaction Response Code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
-          puts "User Fields: "
-          response.transactionResponse.userFields.userFields.each do |userField|
-            puts userField.value
+          if response.transactionResponse.responseCode == '1'
+            puts "Successful charge (auth + capture) (authorization code: #{response.transactionResponse.authCode})"
+            puts "Transaction ID: #{response.transactionResponse.transId}"
+            puts "Transaction Response Code: #{response.transactionResponse.responseCode}"
+            puts "Code: #{response.transactionResponse.messages.messages[0].code}"
+            puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+            puts "User Fields: "
+            response.transactionResponse.userFields.userFields.each do |userField|
+              puts userField.value
+            end
+          else
+            puts "Transaction Failed"
+            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/charge-credit-card.rb
+++ b/PaymentTransactions/charge-credit-card.rb
@@ -75,8 +75,11 @@ require 'securerandom'
             end
           else
             puts "Transaction Failed"
-            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
-            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            if response.transactionResponse.errors != nil
+              puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+              puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            end
+            raise "Failed to charge card."
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/charge-customer-profile.rb
+++ b/PaymentTransactions/charge-customer-profile.rb
@@ -25,10 +25,16 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
-          puts "Success, Auth Code: #{response.transactionResponse.authCode}"
-          puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          if response.transactionResponse.responseCode == '1'
+            puts "Success, Auth Code: #{response.transactionResponse.authCode}"
+            puts "Transaction Response code: #{response.transactionResponse.responseCode}"
+            puts "Code: #{response.transactionResponse.messages.messages[0].code}"
+            puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          else
+            puts "Transaction Failed"
+            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+          end
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/charge-customer-profile.rb
+++ b/PaymentTransactions/charge-customer-profile.rb
@@ -32,8 +32,11 @@ require 'securerandom'
             puts "Description: #{response.transactionResponse.messages.messages[0].description}"
           else
             puts "Transaction Failed"
-            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
-            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            if response.transactionResponse.errors != nil
+              puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+              puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            end
+            raise "Failed to charge customer profile."
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/charge-tokenized-credit-card.rb
+++ b/PaymentTransactions/charge-tokenized-credit-card.rb
@@ -31,8 +31,11 @@ require 'securerandom'
             puts "Description: #{response.transactionResponse.messages.messages[0].description}"
           else
             puts "Transaction Failed"
-            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
-            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            if response.transactionResponse.errors != nil
+              puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+              puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            end
+            raise "Failed to charge tokenized credit card."
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/charge-tokenized-credit-card.rb
+++ b/PaymentTransactions/charge-tokenized-credit-card.rb
@@ -24,10 +24,16 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
-          puts "Successfully charged tokenized credit card (authorization code: #{response.transactionResponse.authCode})"
-          puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          if response.transactionResponse.responseCode == '1'
+            puts "Successfully charged tokenized credit card (authorization code: #{response.transactionResponse.authCode})"
+            puts "Transaction Response code: #{response.transactionResponse.responseCode}"
+            puts "Code: #{response.transactionResponse.messages.messages[0].code}"
+            puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          else
+            puts "Transaction Failed"
+            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+          end
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/create-chase-pay-transaction.rb
+++ b/PaymentTransactions/create-chase-pay-transaction.rb
@@ -40,8 +40,11 @@ require 'securerandom'
             puts "Description: #{response.transactionResponse.messages.messages[0].description}"
           else
             puts "Transaction Failed"
-            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
-            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            if response.transactionResponse.errors != nil
+              puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+              puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            end
+            raise "Failed to charge tokenized credit card."
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/create-chase-pay-transaction.rb
+++ b/PaymentTransactions/create-chase-pay-transaction.rb
@@ -33,10 +33,16 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
-          puts "Successfully created transaction with Transaction ID: #{response.transactionResponse.transId}"
-          puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          if response.transactionResponse.responseCode == '1'
+            puts "Successfully created transaction with Transaction ID: #{response.transactionResponse.transId}"
+            puts "Transaction Response code: #{response.transactionResponse.responseCode}"
+            puts "Code: #{response.transactionResponse.messages.messages[0].code}"
+            puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          else
+            puts "Transaction Failed"
+            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+          end
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/credit-bank-account.rb
+++ b/PaymentTransactions/credit-bank-account.rb
@@ -25,10 +25,16 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && (response.transactionResponse.messages != nil)
-          puts "Successfully credited (Transaction ID: #{response.transactionResponse.transId})"
-          puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          if response.transactionResponse.responseCode == '1'
+            puts "Successfully credited (Transaction ID: #{response.transactionResponse.transId})"
+            puts "Transaction Response code: #{response.transactionResponse.responseCode}"
+            puts "Code: #{response.transactionResponse.messages.messages[0].code}"
+            puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          else
+            puts "Transaction Failed"
+            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+          end
         else
           puts "Transaction Failed"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"

--- a/PaymentTransactions/credit-bank-account.rb
+++ b/PaymentTransactions/credit-bank-account.rb
@@ -32,6 +32,11 @@ require 'securerandom'
             puts "Description: #{response.transactionResponse.messages.messages[0].description}"
           else
             puts "Transaction Failed"
+            if response.transactionResponse.errors != nil
+              puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+              puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            end
+            puts "Failed to credit bank account."
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/credit-bank-account.rb
+++ b/PaymentTransactions/credit-bank-account.rb
@@ -32,8 +32,6 @@ require 'securerandom'
             puts "Description: #{response.transactionResponse.messages.messages[0].description}"
           else
             puts "Transaction Failed"
-            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
-            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/debit-bank-account.rb
+++ b/PaymentTransactions/debit-bank-account.rb
@@ -26,11 +26,17 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && (response.transactionResponse.messages != nil)
-          puts "Successfully debited bank account."
-          puts "  Transaction ID: #{response.transactionResponse.transId}"
-          puts "  Transaction response code: #{response.transactionResponse.responseCode}"
-          puts "  Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages.messages[0].description}"
+          if response.transactionResponse.responseCode == '1'
+            puts "Successfully debited bank account."
+            puts "  Transaction ID: #{response.transactionResponse.transId}"
+            puts "  Transaction response code: #{response.transactionResponse.responseCode}"
+            puts "  Code: #{response.transactionResponse.messages.messages[0].code}"
+            puts "  Description: #{response.transactionResponse.messages.messages[0].description}"
+          else
+            puts 'Transaction Failed'
+            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+          end
         else
           puts "Transaction Failed"
           puts "Transaction response code: #{response.transactionResponse.responseCode}"          

--- a/PaymentTransactions/debit-bank-account.rb
+++ b/PaymentTransactions/debit-bank-account.rb
@@ -34,8 +34,12 @@ require 'securerandom'
             puts "  Description: #{response.transactionResponse.messages.messages[0].description}"
           else
             puts 'Transaction Failed'
-            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
-            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            puts "Transaction response code: #{response.transactionResponse.responseCode}"          
+            if response.transactionResponse.errors != nil
+              puts "  Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+              puts "  Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            end
+            puts "Failed to debit bank account."
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/refund-transaction.rb
+++ b/PaymentTransactions/refund-transaction.rb
@@ -31,8 +31,11 @@ require 'securerandom'
             puts "Description: #{response.transactionResponse.messages.messages[0].description}"
           else
             puts 'Transaction Failed'
-            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
-            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            if response.transactionResponse.errors != nil
+              puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+              puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            end
+            raise "Failed to refund a transaction."
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/refund-transaction.rb
+++ b/PaymentTransactions/refund-transaction.rb
@@ -24,10 +24,16 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
-          puts "Successfully refunded a transaction (Transaction ID #{response.transactionResponse.transId})"
-          puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          if response.transactionResponse.responseCode == '1'
+            puts "Successfully refunded a transaction (Transaction ID #{response.transactionResponse.transId})"
+            puts "Transaction Response code: #{response.transactionResponse.responseCode}"
+            puts "Code: #{response.transactionResponse.messages.messages[0].code}"
+            puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          else
+            puts 'Transaction Failed'
+            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+          end
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/void-transaction.rb
+++ b/PaymentTransactions/void-transaction.rb
@@ -34,8 +34,11 @@ require 'securerandom'
             puts "Description: #{response.transactionResponse.messages.messages[0].description}"
           else
             puts 'Transaction Failed'
-            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
-            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            if response.transactionResponse.errors != nil
+              puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+              puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+            end
+            raise "Failed to authorize card."
           end
         else
           puts "Transaction Failed"

--- a/PaymentTransactions/void-transaction.rb
+++ b/PaymentTransactions/void-transaction.rb
@@ -25,12 +25,18 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
-          puts "Successful AuthCapture Transaction (authorization code: #{response.transactionResponse.authCode})"
-          authTransId = response.transactionResponse.transId
-          puts "Transaction ID (for later void: #{authTransId})"
-          puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          if response.transactionResponse.responseCode == '1'
+            puts "Successful AuthCapture Transaction (authorization code: #{response.transactionResponse.authCode})"
+            authTransId = response.transactionResponse.transId
+            puts "Transaction ID (for later void: #{authTransId})"
+            puts "Transaction Response code: #{response.transactionResponse.responseCode}"
+            puts "Code: #{response.transactionResponse.messages.messages[0].code}"
+            puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          else
+            puts 'Transaction Failed'
+            puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
+            puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
+          end
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil


### PR DESCRIPTION
These updates to the PaymentTransactions examples should help to alleviate some of the confusion as to what constitutes a successful transaction coming back from Authorize.Net when using the `authorizenet` gem.

The current examples don't show checking the actual response code to verify if the transaction was successful, rather they show only the check on whether the Authorize.Net API successfully processed the request (not if the transaction was successful, declined, held for AFDS, failed for some other reason).