### PR TITLE
Repair all broken examples with the correct messages API reference

### DIFF
--- a/AcceptSuite/create-an-accept-payment-transaction.rb
+++ b/AcceptSuite/create-an-accept-payment-transaction.rb
@@ -27,8 +27,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successful charge (auth + capture) (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -43,8 +43,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to charge card."
       end

--- a/AcceptSuite/create-an-accept-payment-transaction.rb
+++ b/AcceptSuite/create-an-accept-payment-transaction.rb
@@ -27,8 +27,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successful charge (auth + capture) (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/AcceptSuite/get-accept-customer-profile-page.rb
+++ b/AcceptSuite/get-accept-customer-profile-page.rb
@@ -23,12 +23,12 @@ require 'securerandom'
     
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successfully got Accept Customer page token."
-      puts "  Response code: #{response.messages.messages[0].code}"
-      puts "  Response message: #{response.messages.messages[0].text}"
+      puts "  Response code: #{response.messages.message[0].code}"
+      puts "  Response message: #{response.messages.message[0].text}"
       puts "  Token: #{response.token}"
     else
-      puts "#{response.messages.messages[0].code}"
-      puts "#{response.messages.messages[0].text}"
+      puts "#{response.messages.message[0].code}"
+      puts "#{response.messages.message[0].text}"
       raise "Failed to get hosted profile page with customer profile ID #{request.customerProfileId}"
     end
     return response

--- a/AcceptSuite/get-an-accept-payment-page.rb
+++ b/AcceptSuite/get-an-accept-payment-page.rb
@@ -26,12 +26,12 @@ require 'securerandom'
     response = transaction.get_hosted_payment_page(request)
     
     if response.messages.resultCode == MessageTypeEnum::Ok
-      puts "#{response.messages.messages[0].code}"
-      puts "#{response.messages.messages[0].text}"
+      puts "#{response.messages.message[0].code}"
+      puts "#{response.messages.message[0].text}"
       puts "#{response.token}"
     else
-      puts "#{response.messages.messages[0].code}"
-      puts "#{response.messages.messages[0].text}"
+      puts "#{response.messages.message[0].code}"
+      puts "#{response.messages.message[0].text}"
       raise "Failed to get hosted payment page"
     end
     return response

--- a/CustomerProfiles/create-customer-payment-profile.rb
+++ b/CustomerProfiles/create-customer-payment-profile.rb
@@ -46,8 +46,8 @@ require 'securerandom'
       if response.messages.resultCode == MessageTypeEnum::Ok
         puts "Successfully created a customer payment profile with id: #{response.customerPaymentProfileId}."
       else
-        puts response.messages.messages[0].code        
-        puts response.messages.messages[0].text
+        puts response.messages.message[0].code
+        puts response.messages.message[0].text
         puts "Failed to create a new customer payment profile."
       end
     else

--- a/CustomerProfiles/create-customer-profile-from-transaction.rb
+++ b/CustomerProfiles/create-customer-profile-from-transaction.rb
@@ -40,7 +40,7 @@ require 'securerandom'
       puts "New customer payment profile ID: #{response.customerPaymentProfileIdList.numericString[0]}"
       puts "New customer shipping profile ID (if created): #{response.customerShippingAddressIdList.numericString[0]}"
     else
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].text
       raise "Failed to create a customer profile from an existing transaction."
     end
     return response

--- a/CustomerProfiles/create-customer-profile.rb
+++ b/CustomerProfiles/create-customer-profile.rb
@@ -74,8 +74,8 @@ require 'securerandom'
         end
         puts 
       else
-        puts response.messages.messages[0].code        
-        puts response.messages.messages[0].text
+        puts response.messages.message[0].code
+        puts response.messages.message[0].text
         raise "Failed to create a new customer profile."
       end
     else

--- a/CustomerProfiles/create-customer-shipping-address.rb
+++ b/CustomerProfiles/create-customer-shipping-address.rb
@@ -9,7 +9,6 @@ require 'securerandom'
     config = YAML.load_file(File.dirname(__FILE__) + "/../credentials.yml")
 
     transaction = Transaction.new(config['api_login_id'], config['api_transaction_key'], :gateway => :sandbox)
-
     
     request = CreateCustomerShippingAddressRequest.new
     
@@ -17,11 +16,10 @@ require 'securerandom'
     request.customerProfileId = customerProfileId
     response = transaction.create_customer_shipping_profile(request)
 
-
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successfully created a customer shipping address with id:  #{response.customerAddressId}."
     else
-      puts "Failed to create a new customer shipping address: #{response.messages.messages[0].text}"      
+      puts "Failed to create a new customer shipping address: #{response.messages.message[0].text}"
     end
     return response
   end

--- a/CustomerProfiles/delete-customer-payment-profile.rb
+++ b/CustomerProfiles/delete-customer-payment-profile.rb
@@ -21,7 +21,7 @@ require 'securerandom'
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successfully deleted payment profile with customer payment profile ID #{request.customerPaymentProfileId}."
     else
-      puts "Failed to delete payment profile with profile ID #{request.customerPaymentProfileId}: #{response.messages.messages[0].text}"
+      puts "Failed to delete payment profile with profile ID #{request.customerPaymentProfileId}: #{response.messages.message[0].text}"
     end
     return response
   end

--- a/CustomerProfiles/delete-customer-profile.rb
+++ b/CustomerProfiles/delete-customer-profile.rb
@@ -20,7 +20,7 @@ require 'securerandom'
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successfully deleted customer with customer profile ID #{request.customerProfileId}."
     else
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].text
       raise "Failed to delete customer with customer profile ID #{request.customerProfileId}."
     end
     return response

--- a/CustomerProfiles/delete-customer-shipping-address.rb
+++ b/CustomerProfiles/delete-customer-shipping-address.rb
@@ -21,7 +21,7 @@ require 'securerandom'
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successfully deleted shipping address with customer shipping profile ID #{request.customerAddressId}."
     else
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].text
       raise "Failed to delete payment profile with profile ID #{request.customerAddressId}."
     end
     return response

--- a/CustomerProfiles/get-customer-payment-profile-list.rb
+++ b/CustomerProfiles/get-customer-payment-profile-list.rb
@@ -32,8 +32,8 @@ require 'securerandom'
     
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successfully got customer payment profile list."
-      puts response.messages.messages[0].code
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].code
+      puts response.messages.message[0].text
       puts "  Total number in result set: #{response.totalNumInResultSet}"
 #      response.paymentProfiles.paymentProfile.each do |paymentProfile|
 #        puts "Payment profile ID = #{paymentProfile.customerPaymentProfileId}"
@@ -41,8 +41,8 @@ require 'securerandom'
 #        puts "Credit Card Number = #{paymentProfile.payment.creditCard.cardNumber}"
 #      end
     else
-      puts response.messages.messages[0].code
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].code
+      puts response.messages.message[0].text
       raise "Failed to get customer payment profile list"
     end
     return response

--- a/CustomerProfiles/get-customer-payment-profile.rb
+++ b/CustomerProfiles/get-customer-payment-profile.rb
@@ -29,7 +29,7 @@ require 'securerandom'
       end
 
     else
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].text
       raise "Failed to get payment profile information with ID #{request.customerPaymentProfileId}."
     end 
     return response

--- a/CustomerProfiles/get-customer-profile-ids.rb
+++ b/CustomerProfiles/get-customer-profile-ids.rb
@@ -33,7 +33,7 @@ require 'securerandom'
       # end
 
     else
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].text
       raise "Failed to get customer IDs."
     end
     return response

--- a/CustomerProfiles/get-customer-profile.rb
+++ b/CustomerProfiles/get-customer-profile.rb
@@ -42,7 +42,7 @@ require 'securerandom'
       end
 
     else
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].text
       raise "Failed to get customer profile information with ID #{request.customerProfileId}"
     end
     return response

--- a/CustomerProfiles/get-customer-shipping-address.rb
+++ b/CustomerProfiles/get-customer-shipping-address.rb
@@ -29,7 +29,7 @@ require 'securerandom'
       end
 
     else
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].text
       raise "Failed to get payment profile information with ID #{request.customerProfileId}"
     end
     return response

--- a/CustomerProfiles/update-customer-payment-profile.rb
+++ b/CustomerProfiles/update-customer-payment-profile.rb
@@ -25,7 +25,7 @@ require 'securerandom'
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successfully updated customer payment profile with  ID #{request.paymentProfile.customerPaymentProfileId}."
     else
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].text
       raise "Failed to update customer with customer payment profile ID #{request.paymentProfile.customerPaymentProfileId}."
     end
     return response

--- a/CustomerProfiles/update-customer-profile.rb
+++ b/CustomerProfiles/update-customer-profile.rb
@@ -25,7 +25,7 @@ require 'securerandom'
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successfully updated customer with customer profile ID #{request.profile.customerProfileId}."
     else
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].text
       raise "Failed to update customer with customer profile ID #{request.profile.customerProfileId}."
     end
     return response

--- a/CustomerProfiles/update-customer-shipping-address.rb
+++ b/CustomerProfiles/update-customer-shipping-address.rb
@@ -26,7 +26,7 @@ require 'securerandom'
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successfully updated customer with customer profile ID #{request.address.customerAddressId}."
     else
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].text
       raise "Failed to update customer with customer profile ID #{request.address.customerAddressId}."
     end
     return response

--- a/CustomerProfiles/validate-customer-payment-profile.rb
+++ b/CustomerProfiles/validate-customer-payment-profile.rb
@@ -23,8 +23,8 @@ def validate_customer_payment_profile(customerProfileId = '36152115', customerPa
 	  puts "Successfully validated customer with customer profile ID #{request.customerProfileId}"
 	  puts "Direct Response: #{response.directResponse} "
 	else
-	    puts response.messages.messages[0].code
-	    puts response.messages.messages[0].text
+	    puts response.messages.message[0].code
+	    puts response.messages.message[0].text
 	    raise "Failed to validate customer with customer profile ID #{request.customerProfileId} and payment profile ID #{customerPaymentProfileId}"
 	end
 

--- a/FraudManagement/approve-or-decline-held-transaction.rb
+++ b/FraudManagement/approve-or-decline-held-transaction.rb
@@ -23,8 +23,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully updated transaction: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Update Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/FraudManagement/approve-or-decline-held-transaction.rb
+++ b/FraudManagement/approve-or-decline-held-transaction.rb
@@ -23,8 +23,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully updated transaction: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Update Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -39,8 +39,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to update transaction."
       end

--- a/FraudManagement/get-held-transaction-list.rb
+++ b/FraudManagement/get-held-transaction-list.rb
@@ -33,8 +33,8 @@ require 'securerandom'
         end
         puts "Total transaction received #{unsettled_transactions.transaction.length}"
       else
-        puts "ERROR message: #{response.messages.messages[0].text}"
-        puts "ERROR code: #{response.messages.messages[0].code}"
+        puts "ERROR message: #{response.messages.message[0].text}"
+        puts "ERROR code: #{response.messages.message[0].code}"
         raise "Failed to get unsettled transaction list."
       end
     

--- a/MobileInAppTransactions/create-an-accept-transaction.rb
+++ b/MobileInAppTransactions/create-an-accept-transaction.rb
@@ -25,8 +25,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully made a purchase (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -41,8 +41,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to make a purchase."
       end

--- a/MobileInAppTransactions/create-an-accept-transaction.rb
+++ b/MobileInAppTransactions/create-an-accept-transaction.rb
@@ -25,8 +25,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully made a purchase (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/MobileInAppTransactions/create-an-android-pay-transaction.rb
+++ b/MobileInAppTransactions/create-an-android-pay-transaction.rb
@@ -25,8 +25,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully made a purchase (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/MobileInAppTransactions/create-an-android-pay-transaction.rb
+++ b/MobileInAppTransactions/create-an-android-pay-transaction.rb
@@ -25,8 +25,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully made a purchase (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -41,8 +41,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to make purchase."
       end

--- a/MobileInAppTransactions/create-an-apple-pay-transaction.rb
+++ b/MobileInAppTransactions/create-an-apple-pay-transaction.rb
@@ -24,8 +24,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully made a purchase (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -40,8 +40,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to make purchase."
       end

--- a/MobileInAppTransactions/create-an-apple-pay-transaction.rb
+++ b/MobileInAppTransactions/create-an-apple-pay-transaction.rb
@@ -24,8 +24,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully made a purchase (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PayPalExpressCheckout/authorization-and-capture-continued.rb
+++ b/PayPalExpressCheckout/authorization-and-capture-continued.rb
@@ -34,8 +34,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully created an Authorization Capture-Continue transaction (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PayPalExpressCheckout/authorization-and-capture-continued.rb
+++ b/PayPalExpressCheckout/authorization-and-capture-continued.rb
@@ -34,8 +34,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully created an Authorization Capture-Continue transaction (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -50,8 +50,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to make purchase."
       end

--- a/PayPalExpressCheckout/authorization-and-capture.rb
+++ b/PayPalExpressCheckout/authorization-and-capture.rb
@@ -35,8 +35,8 @@ require 'securerandom'
           puts "  Transaction ID: #{response.transactionResponse.transId}"
           puts "  Secure Acceptance URL: #{response.transactionResponse.secureAcceptance.SecureAcceptanceUrl}"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "  Code: #{response.transactionResponse.messages.message[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "  Code: #{response.transactionResponse.messages[0].code}"
+		      puts "  Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "PayPal authorize and capture transaction failed"
           if response.transactionResponse.errors != nil

--- a/PayPalExpressCheckout/authorization-and-capture.rb
+++ b/PayPalExpressCheckout/authorization-and-capture.rb
@@ -35,8 +35,8 @@ require 'securerandom'
           puts "  Transaction ID: #{response.transactionResponse.transId}"
           puts "  Secure Acceptance URL: #{response.transactionResponse.secureAcceptance.SecureAcceptanceUrl}"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "  Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "  Code: #{response.transactionResponse.messages.message[0].code}"
+		      puts "  Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "PayPal authorize and capture transaction failed"
           if response.transactionResponse.errors != nil
@@ -51,8 +51,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed PayPal Authorize Capture Transaction."
       end

--- a/PayPalExpressCheckout/authorization-and-capture.rb
+++ b/PayPalExpressCheckout/authorization-and-capture.rb
@@ -36,7 +36,7 @@ require 'securerandom'
           puts "  Secure Acceptance URL: #{response.transactionResponse.secureAcceptance.SecureAcceptanceUrl}"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
           puts "  Code: #{response.transactionResponse.messages[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages[0].description}"
+          puts "  Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "PayPal authorize and capture transaction failed"
           if response.transactionResponse.errors != nil

--- a/PayPalExpressCheckout/authorization-only-continued.rb
+++ b/PayPalExpressCheckout/authorization-only-continued.rb
@@ -35,8 +35,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successful AuthOnly Transaction (Transaction response code: #{response.transactionResponse.responseCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -51,8 +51,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         puts "Failed to authorize card."
       end

--- a/PayPalExpressCheckout/authorization-only-continued.rb
+++ b/PayPalExpressCheckout/authorization-only-continued.rb
@@ -35,8 +35,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successful AuthOnly Transaction (Transaction response code: #{response.transactionResponse.responseCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PayPalExpressCheckout/authorization-only.rb
+++ b/PayPalExpressCheckout/authorization-only.rb
@@ -36,8 +36,8 @@ require 'securerandom'
           puts "  Transaction ID: #{response.transactionResponse.transId}"
           puts "  Secure Acceptance URL: #{response.transactionResponse.secureAcceptance.SecureAcceptanceUrl}"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "  Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "  Code: #{response.transactionResponse.messages.message[0].code}"
+		      puts "  Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "PayPal authorize only transaction failed"
           if response.transactionResponse.errors != nil
@@ -52,8 +52,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed PayPal Authorize Only Transaction."
       end

--- a/PayPalExpressCheckout/authorization-only.rb
+++ b/PayPalExpressCheckout/authorization-only.rb
@@ -37,7 +37,7 @@ require 'securerandom'
           puts "  Secure Acceptance URL: #{response.transactionResponse.secureAcceptance.SecureAcceptanceUrl}"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
           puts "  Code: #{response.transactionResponse.messages[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages[0].description}"
+          puts "  Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "PayPal authorize only transaction failed"
           if response.transactionResponse.errors != nil

--- a/PayPalExpressCheckout/authorization-only.rb
+++ b/PayPalExpressCheckout/authorization-only.rb
@@ -36,8 +36,8 @@ require 'securerandom'
           puts "  Transaction ID: #{response.transactionResponse.transId}"
           puts "  Secure Acceptance URL: #{response.transactionResponse.secureAcceptance.SecureAcceptanceUrl}"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "  Code: #{response.transactionResponse.messages.message[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "  Code: #{response.transactionResponse.messages[0].code}"
+		      puts "  Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "PayPal authorize only transaction failed"
           if response.transactionResponse.errors != nil

--- a/PayPalExpressCheckout/credit.rb
+++ b/PayPalExpressCheckout/credit.rb
@@ -33,8 +33,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successful Credit Transaction (Transaction response code: #{response.transactionResponse.responseCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PayPalExpressCheckout/credit.rb
+++ b/PayPalExpressCheckout/credit.rb
@@ -33,8 +33,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successful Credit Transaction (Transaction response code: #{response.transactionResponse.responseCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -49,8 +49,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to authorize card."
       end

--- a/PayPalExpressCheckout/get-details.rb
+++ b/PayPalExpressCheckout/get-details.rb
@@ -37,8 +37,8 @@ require 'securerandom'
             puts "Payer ID: #{response.transactionResponse.secureAcceptance.PayerID}"
           end
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PayPalExpressCheckout/get-details.rb
+++ b/PayPalExpressCheckout/get-details.rb
@@ -37,8 +37,8 @@ require 'securerandom'
             puts "Payer ID: #{response.transactionResponse.secureAcceptance.PayerID}"
           end
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -52,8 +52,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
       end
     else

--- a/PayPalExpressCheckout/prior-authorization-capture.rb
+++ b/PayPalExpressCheckout/prior-authorization-capture.rb
@@ -28,8 +28,8 @@ require 'securerandom'
           puts "Successful AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
           refTransId =  response.transactionResponse.transId
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -78,8 +78,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully created a Prior Authorization capture transaction (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PayPalExpressCheckout/prior-authorization-capture.rb
+++ b/PayPalExpressCheckout/prior-authorization-capture.rb
@@ -28,8 +28,8 @@ require 'securerandom'
           puts "Successful AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
           refTransId =  response.transactionResponse.transId
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -44,8 +44,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to authorize card."
       end
@@ -78,8 +78,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully created a Prior Authorization capture transaction (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -94,8 +94,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to make purchase."
       end

--- a/PayPalExpressCheckout/void.rb
+++ b/PayPalExpressCheckout/void.rb
@@ -29,8 +29,8 @@ require 'securerandom'
           authTransId = response.transactionResponse.transId
           puts "  Transaction ID (for later void: #{authTransId})"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "  Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "  Code: #{response.transactionResponse.messages.message[0].code}"
+		      puts "  Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -45,8 +45,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to authorize card."
       end
@@ -78,8 +78,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully voided the transaction (Transaction ID: #{response.transactionResponse.transId})"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "  Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "  Code: #{response.transactionResponse.messages.message[0].code}"
+		      puts "  Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -94,8 +94,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to void the transaction."
       end

--- a/PayPalExpressCheckout/void.rb
+++ b/PayPalExpressCheckout/void.rb
@@ -30,7 +30,7 @@ require 'securerandom'
           puts "  Transaction ID (for later void: #{authTransId})"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
           puts "  Code: #{response.transactionResponse.messages[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages[0].description}"
+          puts "  Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -79,7 +79,7 @@ require 'securerandom'
           puts "Successfully voided the transaction (Transaction ID: #{response.transactionResponse.transId})"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
           puts "  Code: #{response.transactionResponse.messages[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages[0].description}"
+          puts "  Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PayPalExpressCheckout/void.rb
+++ b/PayPalExpressCheckout/void.rb
@@ -29,8 +29,8 @@ require 'securerandom'
           authTransId = response.transactionResponse.transId
           puts "  Transaction ID (for later void: #{authTransId})"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "  Code: #{response.transactionResponse.messages.message[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "  Code: #{response.transactionResponse.messages[0].code}"
+		      puts "  Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -78,8 +78,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully voided the transaction (Transaction ID: #{response.transactionResponse.transId})"
           puts "  Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "  Code: #{response.transactionResponse.messages.message[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "  Code: #{response.transactionResponse.messages[0].code}"
+		      puts "  Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/authorize-credit-card.rb
+++ b/PaymentTransactions/authorize-credit-card.rb
@@ -65,8 +65,8 @@ require 'securerandom'
           puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction ID: #{response.transactionResponse.transId}"
           puts "Transaction Response Code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-          puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
           puts "User Fields: "
           response.transactionResponse.userFields.userFields.each do |userField|
             puts userField.value
@@ -85,8 +85,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to authorize card."
       end

--- a/PaymentTransactions/authorize-credit-card.rb
+++ b/PaymentTransactions/authorize-credit-card.rb
@@ -65,8 +65,8 @@ require 'securerandom'
           puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction ID: #{response.transactionResponse.transId}"
           puts "Transaction Response Code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
           puts "User Fields: "
           response.transactionResponse.userFields.userFields.each do |userField|
             puts userField.value

--- a/PaymentTransactions/capture-funds-authorized-through-another-channel.rb
+++ b/PaymentTransactions/capture-funds-authorized-through-another-channel.rb
@@ -26,8 +26,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -42,8 +42,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to authorize card."
       end

--- a/PaymentTransactions/capture-funds-authorized-through-another-channel.rb
+++ b/PaymentTransactions/capture-funds-authorized-through-another-channel.rb
@@ -26,8 +26,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/capture-previously-authorized-amount.rb
+++ b/PaymentTransactions/capture-previously-authorized-amount.rb
@@ -29,8 +29,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
           puts "Transaction ID: #{response.transactionResponse.transId} (for later capture)"
         else
           puts "Transaction Failed"
@@ -46,8 +46,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to authorize card."
       end
@@ -70,8 +70,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully captured the authorized amount (Transaction ID: #{response.transactionResponse.transId})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -86,8 +86,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to capture."
       end

--- a/PaymentTransactions/capture-previously-authorized-amount.rb
+++ b/PaymentTransactions/capture-previously-authorized-amount.rb
@@ -29,8 +29,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully created an AuthOnly Transaction (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
           puts "Transaction ID: #{response.transactionResponse.transId} (for later capture)"
         else
           puts "Transaction Failed"
@@ -70,8 +70,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully captured the authorized amount (Transaction ID: #{response.transactionResponse.transId})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/charge-credit-card.rb
+++ b/PaymentTransactions/charge-credit-card.rb
@@ -66,8 +66,8 @@ require 'securerandom'
           puts "Successful charge (auth + capture) (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction ID: #{response.transactionResponse.transId}"
           puts "Transaction Response Code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
           puts "User Fields: "
           response.transactionResponse.userFields.userFields.each do |userField|
             puts userField.value

--- a/PaymentTransactions/charge-credit-card.rb
+++ b/PaymentTransactions/charge-credit-card.rb
@@ -66,8 +66,8 @@ require 'securerandom'
           puts "Successful charge (auth + capture) (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction ID: #{response.transactionResponse.transId}"
           puts "Transaction Response Code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
           puts "User Fields: "
           response.transactionResponse.userFields.userFields.each do |userField|
             puts userField.value
@@ -86,8 +86,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to charge card."
       end

--- a/PaymentTransactions/charge-customer-profile.rb
+++ b/PaymentTransactions/charge-customer-profile.rb
@@ -27,8 +27,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Success, Auth Code: #{response.transactionResponse.authCode}"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/charge-customer-profile.rb
+++ b/PaymentTransactions/charge-customer-profile.rb
@@ -27,8 +27,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Success, Auth Code: #{response.transactionResponse.authCode}"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -43,8 +43,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to charge customer profile."
       end

--- a/PaymentTransactions/charge-tokenized-credit-card.rb
+++ b/PaymentTransactions/charge-tokenized-credit-card.rb
@@ -26,8 +26,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully charged tokenized credit card (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/charge-tokenized-credit-card.rb
+++ b/PaymentTransactions/charge-tokenized-credit-card.rb
@@ -26,8 +26,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully charged tokenized credit card (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -42,8 +42,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to charge tokenized credit card."
       end

--- a/PaymentTransactions/create-chase-pay-transaction.rb
+++ b/PaymentTransactions/create-chase-pay-transaction.rb
@@ -35,8 +35,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully created transaction with Transaction ID: #{response.transactionResponse.transId}"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/create-chase-pay-transaction.rb
+++ b/PaymentTransactions/create-chase-pay-transaction.rb
@@ -35,8 +35,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully created transaction with Transaction ID: #{response.transactionResponse.transId}"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -51,8 +51,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to charge tokenized credit card."
       end

--- a/PaymentTransactions/credit-bank-account.rb
+++ b/PaymentTransactions/credit-bank-account.rb
@@ -27,8 +27,8 @@ require 'securerandom'
         if response.transactionResponse != nil && (response.transactionResponse.messages != nil)
           puts "Successfully credited (Transaction ID: #{response.transactionResponse.transId})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
@@ -44,8 +44,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         puts "Failed to credit bank account."
       end

--- a/PaymentTransactions/credit-bank-account.rb
+++ b/PaymentTransactions/credit-bank-account.rb
@@ -27,8 +27,8 @@ require 'securerandom'
         if response.transactionResponse != nil && (response.transactionResponse.messages != nil)
           puts "Successfully credited (Transaction ID: #{response.transactionResponse.transId})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"

--- a/PaymentTransactions/debit-bank-account.rb
+++ b/PaymentTransactions/debit-bank-account.rb
@@ -30,7 +30,7 @@ require 'securerandom'
           puts "  Transaction ID: #{response.transactionResponse.transId}"
           puts "  Transaction response code: #{response.transactionResponse.responseCode}"
           puts "  Code: #{response.transactionResponse.messages[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages[0].description}"
+          puts "  Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           puts "Transaction response code: #{response.transactionResponse.responseCode}"          

--- a/PaymentTransactions/debit-bank-account.rb
+++ b/PaymentTransactions/debit-bank-account.rb
@@ -29,8 +29,8 @@ require 'securerandom'
           puts "Successfully debited bank account."
           puts "  Transaction ID: #{response.transactionResponse.transId}"
           puts "  Transaction response code: #{response.transactionResponse.responseCode}"
-          puts "  Code: #{response.transactionResponse.messages.message[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "  Code: #{response.transactionResponse.messages[0].code}"
+		      puts "  Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           puts "Transaction response code: #{response.transactionResponse.responseCode}"          

--- a/PaymentTransactions/debit-bank-account.rb
+++ b/PaymentTransactions/debit-bank-account.rb
@@ -29,8 +29,8 @@ require 'securerandom'
           puts "Successfully debited bank account."
           puts "  Transaction ID: #{response.transactionResponse.transId}"
           puts "  Transaction response code: #{response.transactionResponse.responseCode}"
-          puts "  Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "  Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "  Code: #{response.transactionResponse.messages.message[0].code}"
+		      puts "  Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           puts "Transaction response code: #{response.transactionResponse.responseCode}"          
@@ -46,8 +46,8 @@ require 'securerandom'
           puts "  Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "  Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "  Error Code: #{response.messages.messages[0].code}"
-          puts "  Error Message: #{response.messages.messages[0].text}"
+          puts "  Error Code: #{response.messages.message[0].code}"
+          puts "  Error Message: #{response.messages.message[0].text}"
         end
         puts "Failed to debit bank account."
       end

--- a/PaymentTransactions/refund-transaction.rb
+++ b/PaymentTransactions/refund-transaction.rb
@@ -26,8 +26,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully refunded a transaction (Transaction ID #{response.transactionResponse.transId})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/refund-transaction.rb
+++ b/PaymentTransactions/refund-transaction.rb
@@ -26,8 +26,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully refunded a transaction (Transaction ID #{response.transactionResponse.transId})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -42,8 +42,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to refund a transaction."
       end

--- a/PaymentTransactions/update-split-tender-group.rb
+++ b/PaymentTransactions/update-split-tender-group.rb
@@ -27,12 +27,12 @@ require 'securerandom'
   
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successful Update Split Tender Group"
-      puts response.messages.messages[0].code
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].code
+      puts response.messages.message[0].text
   
     else
-      puts response.messages.messages[0].code
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].code
+      puts response.messages.message[0].text
       raise "Failed to update split tender group."
     end
     

--- a/PaymentTransactions/void-transaction.rb
+++ b/PaymentTransactions/void-transaction.rb
@@ -29,8 +29,8 @@ require 'securerandom'
           authTransId = response.transactionResponse.transId
           puts "Transaction ID (for later void: #{authTransId})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -69,8 +69,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully voided the transaction (Transaction ID: #{response.transactionResponse.transId})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/PaymentTransactions/void-transaction.rb
+++ b/PaymentTransactions/void-transaction.rb
@@ -29,8 +29,8 @@ require 'securerandom'
           authTransId = response.transactionResponse.transId
           puts "Transaction ID (for later void: #{authTransId})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -45,8 +45,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to authorize card."
       end
@@ -69,8 +69,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully voided the transaction (Transaction ID: #{response.transactionResponse.transId})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -85,8 +85,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to void the transaction."
       end

--- a/RecurringBilling/cancel-subscription.rb
+++ b/RecurringBilling/cancel-subscription.rb
@@ -19,13 +19,13 @@ require 'securerandom'
       if response != nil
         if response.messages.resultCode == MessageTypeEnum::Ok
           puts "Successfully cancelled a subscription."
-          puts "  Response code: #{response.messages.messages[0].code}"
-          puts "  Response message: #{response.messages.messages[0].text}"
+          puts "  Response code: #{response.messages.message[0].code}"
+          puts "  Response message: #{response.messages.message[0].text}"
         end
       
       else
-        puts response.messages.messages[0].code
-        puts response.messages.messages[0].text
+        puts response.messages.message[0].code
+        puts response.messages.message[0].text
         raise "Failed to cancel a subscription"
       end
       return response

--- a/RecurringBilling/create-subscription-from-customer-profile.rb
+++ b/RecurringBilling/create-subscription-from-customer-profile.rb
@@ -38,8 +38,8 @@ require 'securerandom'
       else
         # puts response.transactionResponse.errors.errors[0].errorCode
         # puts response.transactionResponse.errors.errors[0].errorText
-        puts response.messages.messages[0].code
-        puts response.messages.messages[0].text
+        puts response.messages.message[0].code
+        puts response.messages.message[0].text
         raise "Failed to create a subscription"
       end
     end

--- a/RecurringBilling/create-subscription.rb
+++ b/RecurringBilling/create-subscription.rb
@@ -41,8 +41,8 @@ require 'securerandom'
       else
         #puts response.transactionResponse.errors.errors[0].errorCode
         #puts response.transactionResponse.errors.errors[0].errorText
-        puts response.messages.messages[0].code
-        puts response.messages.messages[0].text
+        puts response.messages.message[0].code
+        puts response.messages.message[0].text
         raise "Failed to create a subscription."
       end
     end

--- a/RecurringBilling/get-list-of-subscriptions.rb
+++ b/RecurringBilling/get-list-of-subscriptions.rb
@@ -28,8 +28,8 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         puts "Successfully got the list of subscriptions."
-        puts "  Response code: #{response.messages.messages[0].code}"
-        puts "  Response message: #{response.messages.messages[0].text}"
+        puts "  Response code: #{response.messages.message[0].code}"
+        puts "  Response message: #{response.messages.message[0].text}"
 
         response.subscriptionDetails.subscriptionDetail.each do |sub|
           puts "  Subscription #{sub.id} #{sub.name} - Status: #{sub.status}"
@@ -38,8 +38,8 @@ require 'securerandom'
     
       else
     
-        puts response.messages.messages[0].code
-        puts response.messages.messages[0].text
+        puts response.messages.message[0].code
+        puts response.messages.message[0].text
         raise "Failed to get the list of subscriptions."
       end
     end

--- a/RecurringBilling/get-subscription-status.rb
+++ b/RecurringBilling/get-subscription-status.rb
@@ -22,8 +22,8 @@ require 'securerandom'
         puts "  Status: #{response.status}"
     
       else
-        puts response.messages.messages[0].code
-        puts response.messages.messages[0].text
+        puts response.messages.message[0].code
+        puts response.messages.message[0].text
         raise "Failed to get a subscriptions status"
       end
     end

--- a/RecurringBilling/get-subscription.rb
+++ b/RecurringBilling/get-subscription.rb
@@ -19,8 +19,8 @@ require 'securerandom'
     
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successfully got subscription details."
-      puts "  Response code: #{response.messages.messages[0].code}"
-      puts "  Response message: #{response.messages.messages[0].text}"
+      puts "  Response code: #{response.messages.message[0].code}"
+      puts "  Response message: #{response.messages.message[0].text}"
       puts "  Subscription name: #{response.subscription.name}"
       puts "  Payment schedule start date: #{response.subscription.paymentSchedule.startDate}"
       puts "  Payment schedule Total Occurrences: #{response.subscription.paymentSchedule.totalOccurrences}"
@@ -29,8 +29,8 @@ require 'securerandom'
       puts "  First Name in Billing Address: #{response.subscription.profile.paymentProfile.billTo.firstName}"
      
     else
-      puts response.messages.messages[0].code
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].code
+      puts response.messages.message[0].text
       raise "Failed to get subscription details."
     end
     

--- a/RecurringBilling/update-subscription.rb
+++ b/RecurringBilling/update-subscription.rb
@@ -34,14 +34,14 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         puts "Successfully updated a subscription."
-        puts "  Response code: #{response.messages.messages[0].code}"
-        puts "  Response message: #{response.messages.messages[0].text}"
+        puts "  Response code: #{response.messages.message[0].code}"
+        puts "  Response message: #{response.messages.message[0].text}"
     
       else
         #puts response.transactionResponse.errors.errors[0].errorCode
         #puts response.transactionResponse.errors.errors[0].errorText
-        puts response.messages.messages[0].code
-        puts response.messages.messages[0].text
+        puts response.messages.message[0].code
+        puts response.messages.message[0].text
         raise "Failed to get a subscriptions status"
       end
     end

--- a/TransactionReporting/get-batch-statistics.rb
+++ b/TransactionReporting/get-batch-statistics.rb
@@ -20,8 +20,8 @@ require 'securerandom'
   if response != nil
     if response.messages.resultCode == MessageTypeEnum::Ok
       puts "Successfully got the list of batch statistics."
-      puts response.messages.messages[0].code
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].code
+      puts response.messages.message[0].text
       puts response.batch.batchId
       puts response.batch.settlementTimeUTC
       puts response.batch.settlementTimeLocal
@@ -42,8 +42,8 @@ require 'securerandom'
   
     else
   
-      puts response.messages.messages[0].code
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].code
+      puts response.messages.message[0].text
       raise "Failed to get the batch statistics"
     end
   end

--- a/TransactionReporting/get-customer-profile-transaction-list.rb
+++ b/TransactionReporting/get-customer-profile-transaction-list.rb
@@ -25,7 +25,7 @@ require 'securerandom'
     if response.messages.resultCode == MessageTypeEnum::Ok
     	transactions = response.transactions
     	if transactions == nil
-    		puts "#{response.messages.messages[0].text}"
+        puts "#{response.messages.message[0].text}"
     	else
         response.transactions.transaction.each do |trans|
   	  		puts "\nTransaction ID :  #{trans.transId} "
@@ -36,8 +36,8 @@ require 'securerandom'
     	end
     else
     	puts "Error: Failed to get Transaction List for customer\n"
-    	puts "Error Text :  #{response.messages.messages[0].text} \n"
-    	puts "Error Code :  #{response.messages.messages[0].code} "
+      puts "Error Text :  #{response.messages.message[0].text} \n"
+      puts "Error Code :  #{response.messages.message[0].code} "
     end
     return response
   

--- a/TransactionReporting/get-merchant-details.rb
+++ b/TransactionReporting/get-merchant-details.rb
@@ -36,8 +36,8 @@ require 'securerandom'
         end
 
       else
-        puts response.messages.messages[0].code
-        puts response.messages.messages[0].text
+        puts response.messages.message[0].code
+        puts response.messages.message[0].text
         raise "Failed to get transaction Details."
       end
     

--- a/TransactionReporting/get-settled-batch-list.rb
+++ b/TransactionReporting/get-settled-batch-list.rb
@@ -33,8 +33,8 @@ require "date"
         puts ""
       end
     else
-        puts response.messages.messages[0].code
-        puts response.messages.messages[0].text
+        puts response.messages.message[0].code
+        puts response.messages.message[0].text
       raise "Failed to fetch settled batch list"
     end
     

--- a/TransactionReporting/get-transaction-details.rb
+++ b/TransactionReporting/get-transaction-details.rb
@@ -27,8 +27,8 @@ require_relative '../PaymentTransactions/authorize-credit-card.rb'
         printf("Auth Amount:  %.2f\n", response.transaction.authAmount)
         printf("Settle Amount:  %.2f\n", response.transaction.settleAmount)
       else
-        puts response.messages.messages[0].code
-        puts response.messages.messages[0].text
+        puts response.messages.message[0].code
+        puts response.messages.message[0].text
         raise "Failed to get transaction Details."
       end
     

--- a/TransactionReporting/get-transaction-list.rb
+++ b/TransactionReporting/get-transaction-list.rb
@@ -27,7 +27,7 @@ require 'securerandom'
     if response != nil
       if response.messages.resultCode == MessageTypeEnum::Ok
         if response.transactions == nil
-          puts "#{response.messages.messages[0].text}"
+          puts "#{response.messages.message[0].text}"
         else
           puts "Successfully got the list of transactions for batch " + batchId + "."          
           response.transactions.transaction.each do |trans|
@@ -39,13 +39,13 @@ require 'securerandom'
         end
       else
         puts "Error: Failed to get Transaction List."
-        puts "Error Text: #{response.messages.messages[0].text}"
-        puts "Error Code: #{response.messages.messages[0].code}"
+        puts "Error Text: #{response.messages.message[0].text}"
+        puts "Error Code: #{response.messages.message[0].code}"
       end
     else
       puts "Error: Failed to get Transaction List."
-      puts "Error Text: #{response.messages.messages[0].text}"
-      puts "Error Code: #{response.messages.messages[0].code}"
+      puts "Error Text: #{response.messages.message[0].text}"
+      puts "Error Code: #{response.messages.message[0].code}"
     end
 
     return response

--- a/TransactionReporting/get-unsettled-transaction-list.rb
+++ b/TransactionReporting/get-unsettled-transaction-list.rb
@@ -34,8 +34,8 @@ require 'securerandom'
         end
         puts "Total transaction received #{unsettled_transactions.transaction.length}"
       else
-        puts "ERROR message: #{response.messages.messages[0].text}"
-        puts "ERROR code: #{response.messages.messages[0].code}"
+        puts "ERROR message: #{response.messages.message[0].text}"
+        puts "ERROR code: #{response.messages.message[0].code}"
         raise "Failed to get unsettled transaction list."
       end
     

--- a/VisaCheckout/create-visa-src-transaction.rb
+++ b/VisaCheckout/create-visa-src-transaction.rb
@@ -27,8 +27,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully made a purchase (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.messages[0].code}"
-		      puts "Description: #{response.transactionResponse.messages.messages[0].description}"
+          puts "Code: #{response.transactionResponse.messages.message[0].code}"
+          puts "Description: #{response.transactionResponse.messages.message[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil
@@ -43,8 +43,8 @@ require 'securerandom'
           puts "Error Code: #{response.transactionResponse.errors.errors[0].errorCode}"
           puts "Error Message: #{response.transactionResponse.errors.errors[0].errorText}"
         else
-          puts "Error Code: #{response.messages.messages[0].code}"
-          puts "Error Message: #{response.messages.messages[0].text}"
+          puts "Error Code: #{response.messages.message[0].code}"
+          puts "Error Message: #{response.messages.message[0].text}"
         end
         raise "Failed to make purchase."
       end

--- a/VisaCheckout/create-visa-src-transaction.rb
+++ b/VisaCheckout/create-visa-src-transaction.rb
@@ -27,8 +27,8 @@ require 'securerandom'
         if response.transactionResponse != nil && response.transactionResponse.messages != nil
           puts "Successfully made a purchase (authorization code: #{response.transactionResponse.authCode})"
           puts "Transaction Response code: #{response.transactionResponse.responseCode}"
-          puts "Code: #{response.transactionResponse.messages.message[0].code}"
-          puts "Description: #{response.transactionResponse.messages.message[0].description}"
+          puts "Code: #{response.transactionResponse.messages[0].code}"
+          puts "Description: #{response.transactionResponse.messages[0].description}"
         else
           puts "Transaction Failed"
           if response.transactionResponse.errors != nil

--- a/VisaCheckout/decrypt-visa-src-data.rb
+++ b/VisaCheckout/decrypt-visa-src-data.rb
@@ -23,8 +23,8 @@ require 'securerandom'
       puts "Shipping Last Name #{response.shippingInfo.lastName}"
       puts "Amount #{response.paymentDetails.amount}"
     else
-      puts response.messages.messages[0].code
-      puts response.messages.messages[0].text
+      puts response.messages.message[0].code
+      puts response.messages.message[0].text
       raise "Failed to decrypt."
     end
     


### PR DESCRIPTION
# Description

Most of the Ruby examples in this repository are broken. They reference `response.messages.messages`, which is incorrect. The API actually returns the `response.messages.message` object (the last `message` object is not plural).

There are also incorrect references to `response.transactionResponse.messages.messages`, where the API actually returns `response.transactionResponse.messages` (notice the missing child object `messages`).

This PR fixes the issue across the repository to align the code with the actual response objects from the API.

## On a side note...

I'm astonished that this repo is riddled with these blatant copy-pasta bugs. All of these Ruby examples are injected into the official Authorize.net documentation located at https://developer.authorize.net/api/reference, so it's bewildering why something with so much exposure is so wrong.